### PR TITLE
Add Qwen3 MoE HF export example

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -81,3 +81,4 @@ class DecoderBlockType(enum.Enum):
   SIMPLE = "simple"
   SIMPLE_MLP = "simple_mlp"
   LLAMA4 = "llama4"
+  QWEN3_MOE = "qwen3_moe"

--- a/MaxText/configs/models/qwen3-moe.yml
+++ b/MaxText/configs/models/qwen3-moe.yml
@@ -1,0 +1,16 @@
+# Model config for Qwen3 MoE
+base_emb_dim: 2048
+base_num_query_heads: 32
+base_num_kv_heads: 4
+base_mlp_dim: 6144
+base_num_decoder_layers: 24
+head_dim: 64
+mlp_activations: ["silu","linear"]
+vocab_size: 151936
+enable_dropout: False
+logits_via_embedding: False
+normalization_layer_epsilon: 1.0e-6
+num_experts: 128
+num_experts_per_tok: 8
+rope_max_timescale: 10000
+decoder_block: "qwen3_moe"

--- a/MaxText/convert_qwen3_moe_ckpt.py
+++ b/MaxText/convert_qwen3_moe_ckpt.py
@@ -1,0 +1,109 @@
+"""Convert weights from a Qwen3 MoE HuggingFace model to a MaxText checkpoint.
+
+This script provides a skeleton for converting the recently released
+Qwen3 Mixture of Experts model. The detailed parameter mapping is not
+yet implemented and must be filled in before use.
+"""
+
+import argparse
+import os
+import pathlib
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from transformers import Qwen3MoeConfig
+
+from MaxText import max_logging
+from MaxText import llama_or_mistral_ckpt
+from MaxText.inference_utils import str2bool
+
+
+def _convert_huggingface_to_jax_weights(base_model_path: str) -> dict:
+    """Convert HuggingFace Qwen3 MoE weights to a MaxText-compatible format."""
+    config = Qwen3MoeConfig.from_pretrained(base_model_path)
+    max_logging.log("Loading Qwen3 MoE checkpoint")
+    ckpt_paths = sorted(pathlib.Path(base_model_path).glob("*.safetensors"))
+    chkpt_vars = {}
+    for ckpt_path in ckpt_paths:
+        with safe_open(ckpt_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                chkpt_vars[key] = f.get_tensor(key)
+
+    jax_weights = {
+        "decoder": {
+            "decoder_norm": {"scale": chkpt_vars["model.norm.weight"].numpy()},
+            "logits_dense": {"kernel": chkpt_vars["lm_head.weight"].numpy().T},
+            "layers": {},
+        },
+        "token_embedder": {"embedding": chkpt_vars["model.embed_tokens.weight"].numpy()},
+    }
+
+    for layer_idx in range(config.num_hidden_layers):
+        layer = {}
+        layer["pre_self_attention_layer_norm"] = {
+            "scale": chkpt_vars[f"model.layers.{layer_idx}.input_layernorm.weight"].numpy()
+        }
+        layer["post_self_attention_layer_norm"] = {
+            "scale": chkpt_vars[f"model.layers.{layer_idx}.post_attention_layernorm.weight"].numpy()
+        }
+        layer["self_attention"] = {
+            "query": {
+                "kernel": chkpt_vars[f"model.layers.{layer_idx}.self_attn.q_proj.weight"].numpy().T
+                / np.sqrt(config.head_dim)
+            },
+            "key": {"kernel": chkpt_vars[f"model.layers.{layer_idx}.self_attn.k_proj.weight"].numpy().T},
+            "value": {"kernel": chkpt_vars[f"model.layers.{layer_idx}.self_attn.v_proj.weight"].numpy().T},
+            "out": {"kernel": chkpt_vars[f"model.layers.{layer_idx}.self_attn.o_proj.weight"].numpy().T},
+        }
+
+        moe = {
+            "gate": {"kernel": chkpt_vars[f"model.layers.{layer_idx}.mlp.gate.weight"].numpy().T},
+            "wi_0": [],
+            "wi_1": [],
+            "wo": [],
+        }
+        for expert_idx in range(config.num_experts):
+            moe["wi_0"].append(
+                chkpt_vars[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight"].numpy().T
+            )
+            moe["wi_1"].append(
+                chkpt_vars[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.up_proj.weight"].numpy().T
+            )
+            moe["wo"].append(
+                chkpt_vars[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight"].numpy().T
+            )
+        moe["wi_0"] = np.stack(moe["wi_0"], axis=0)
+        moe["wi_1"] = np.stack(moe["wi_1"], axis=0)
+        moe["wo"] = np.stack(moe["wo"], axis=0)
+
+        layer["MoeBlock_0"] = moe
+        jax_weights["decoder"]["layers"][f"layer_{layer_idx}"] = layer
+
+    return jax_weights
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert Qwen3 MoE weights.")
+    parser.add_argument("--base_model_path", type=str, required=True)
+    parser.add_argument("--maxtext_model_path", type=str, required=True)
+    parser.add_argument("--simulated_cpu_devices_count", type=int, default=16)
+    parser.add_argument("--use-ocdbt", type=str2bool, default=True)
+    parser.add_argument("--use-zarr3", type=str2bool, default=True)
+    args = parser.parse_args()
+
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={args.simulated_cpu_devices_count}"
+
+    weights = _convert_huggingface_to_jax_weights(args.base_model_path)
+    llama_or_mistral_ckpt.save_weights_to_checkpoint(
+        args.maxtext_model_path,
+        weights,
+        args.simulated_cpu_devices_count,
+        args.use_ocdbt,
+        args.use_zarr3,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -327,6 +327,10 @@ class Decoder(nn.Module):
       from MaxText.layers import mixtral  # pylint: disable=import-outside-toplevel
 
       return [mixtral.MixtralDecoderLayer]
+    elif self.config.decoder_block == DecoderBlockType.QWEN3_MOE:
+      from MaxText.layers import qwen3_moe  # pylint: disable=import-outside-toplevel
+
+      return [qwen3_moe.Qwen3MoeDecoderLayer]
     elif self.config.decoder_block == DecoderBlockType.DEEPSEEK:
       from MaxText.layers import deepseek  # pylint: disable=import-outside-toplevel
 
@@ -372,6 +376,7 @@ class Decoder(nn.Module):
         DecoderBlockType.LLAMA2,
         DecoderBlockType.MISTRAL,
         DecoderBlockType.MIXTRAL,
+        DecoderBlockType.QWEN3_MOE,
         DecoderBlockType.DEEPSEEK,
         DecoderBlockType.GEMMA,
         DecoderBlockType.GEMMA2,

--- a/MaxText/layers/qwen3_moe.py
+++ b/MaxText/layers/qwen3_moe.py
@@ -1,0 +1,144 @@
+"""Decoder layer definition for Qwen3 MoE."""
+# pylint: disable=arguments-differ
+# pylint: disable=no-name-in-module
+
+from typing import Optional
+
+from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+from flax import linen as nn
+
+from MaxText.layers import initializers
+from MaxText.layers import models
+from MaxText.layers import moe
+from MaxText.layers import quantizations
+from MaxText.layers.attentions import Attention
+from MaxText.layers.quantizations import AqtQuantization as Quant
+from MaxText.layers.normalizations import RMSNorm
+
+
+class Qwen3MoeDecoderLayer(nn.Module):
+  """Transformer decoder layer for Qwen3 MoE."""
+
+  config: models.Config
+  mesh: Mesh
+  quant: Optional[Quant] = None
+
+  @nn.compact
+  def __call__(
+      self,
+      inputs,
+      decoder_segment_ids,
+      decoder_positions,
+      deterministic,
+      model_mode,
+      previous_chunk=None,
+      page_state=None,
+      slot=None,
+  ):
+    cfg = self.config
+    mesh = self.mesh
+
+    inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_norm_length", "activation_embed"))
+    inputs = checkpoint_name(inputs, "decoder_layer_input")
+    lnx_rms = RMSNorm(
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="pre_self_attention_layer_norm",
+        kernel_axes=("norm",),
+        epsilon=cfg.normalization_layer_epsilon,
+    )
+    lnx = lnx_rms(inputs)
+
+    lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+
+    attention_layer = Attention(
+        config=cfg,
+        num_query_heads=cfg.num_query_heads,
+        num_kv_heads=cfg.num_kv_heads,
+        head_dim=cfg.head_dim,
+        max_target_length=cfg.max_target_length,
+        max_prefill_predict_length=cfg.max_prefill_predict_length,
+        attention_kernel=cfg.attention,
+        mesh=mesh,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        dropout_rate=cfg.dropout_rate,
+        name="self_attention",
+        float32_qk_product=cfg.float32_qk_product,
+        float32_logits=cfg.float32_logits,
+        quant=self.quant,
+        kv_quant=quantizations.configure_kv_quant(cfg),
+        prefill_cache_axis_order=tuple(map(int, cfg.prefill_cache_axis_order.split(","))),
+        ar_cache_axis_order=tuple(map(int, cfg.ar_cache_axis_order.split(","))),
+        compute_axis_order=tuple(map(int, cfg.compute_axis_order.split(","))),
+    )
+
+    attention_lnx = attention_layer(
+        lnx,
+        lnx,
+        decoder_positions,
+        decoder_segment_ids=decoder_segment_ids,
+        deterministic=deterministic,
+        model_mode=model_mode,
+        previous_chunk=previous_chunk,
+    )
+
+    attention_lnx = nn.with_logical_constraint(
+        attention_lnx, ("activation_batch", "activation_norm_length", "activation_embed")
+    )
+    intermediate_inputs = inputs + attention_lnx
+
+    hidden_states = RMSNorm(
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name="post_self_attention_layer_norm",
+        kernel_axes=("norm",),
+        epsilon=cfg.normalization_layer_epsilon,
+    )(intermediate_inputs)
+    hidden_states = nn.with_logical_constraint(
+        hidden_states, ("activation_batch", "activation_norm_length", "activation_embed")
+    )
+
+    load_balance_loss = None
+    mlp_lnx, load_balance_loss = moe.RoutedMoE(
+        name="MoeBlock_0",
+        config=cfg,
+        num_experts=cfg.num_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        mesh=mesh,
+        kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
+        kernel_axes=("embed", None),
+        intermediate_dim=cfg.mlp_dim,
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        quant=self.quant,
+    )(hidden_states)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_norm_length", "activation_embed"))
+
+    layer_output = mlp_lnx + intermediate_inputs
+    layer_output = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(layer_output, deterministic=deterministic)
+
+    layer_output = nn.with_logical_constraint(
+        layer_output,
+        ("activation_batch", "activation_norm_length", "activation_embed"),
+    )
+
+    if load_balance_loss is not None:
+      self.sow("intermediates", "moe_lb_loss", load_balance_loss)
+
+    if cfg.record_internal_nn_metrics:
+      self.sow("intermediates", "activation_mean", jnp.mean(layer_output))
+      self.sow("intermediates", "activation_stdev", jnp.std(layer_output))
+      self.sow(
+          "intermediates",
+          "activation_fraction_zero",
+          jnp.sum(layer_output == 0) / jnp.size(layer_output),
+      )
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output

--- a/MaxText/tests/check_qwen3_moe_layers.py
+++ b/MaxText/tests/check_qwen3_moe_layers.py
@@ -1,0 +1,34 @@
+import sys
+import unittest
+
+sys.path.insert(0, '/workspace/transformers/src')
+
+import torch
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+from transformers.models.qwen3_moe.modular_qwen3_moe import Qwen3MoeSparseMoeBlock
+
+
+class Qwen3MoeRoutingTest(unittest.TestCase):
+    """Basic tests for Qwen3 MoE routing logic."""
+
+    def test_topk_prob_normalization(self):
+        config = Qwen3MoeConfig(
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=32,
+            num_experts=4,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+        )
+        block = Qwen3MoeSparseMoeBlock(config)
+        hidden_states = torch.randn(2, 3, 16)
+        _output, router_logits = block(hidden_states)
+        probs = torch.softmax(router_logits, dim=-1)
+        topk, _ = torch.topk(probs, config.num_experts_per_tok, dim=-1)
+        sums = topk.sum(dim=-1)
+        ones = torch.ones_like(sums)
+        self.assertTrue(torch.allclose(sums, ones, atol=1e-6))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MaxText/utils/ckpt_conversion/examples/convert_qwen3_moe_to_hf.sh
+++ b/MaxText/utils/ckpt_conversion/examples/convert_qwen3_moe_to_hf.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Example script to convert a MaxText Qwen3 MoE checkpoint back to HuggingFace format.
+set -e
+
+export HF_AUTH_TOKEN=""
+DATE=$(date +%Y-%m-%d)
+
+# Location of the MaxText checkpoint to convert.
+MAXTEXT_CHECKPOINT_DIR="/path/to/maxtext/ckpt"
+
+# Directory where the HuggingFace files will be written.
+LOCAL_HF_CHECKPOINT_DIR="/tmp/hf_qwen3_moe_output"
+
+CONVERT_MODULE="MaxText.ckpt_conversion.to_huggingface"
+CONVERT_ARGS=(
+    "MaxText/configs/base.yml"
+    "model_name=qwen3-moe"
+    "tokenizer_path=${MAXTEXT_CHECKPOINT_DIR}/hf-checkpoint"
+    "load_parameters_path=${MAXTEXT_CHECKPOINT_DIR}"
+    "per_device_batch_size=1"
+    "steps=1"
+    "async_checkpointing=false"
+    "scan_layers=false"
+    "prompt='Hello'"
+    "attention='dot_product'"
+    "base_output_directory=${LOCAL_HF_CHECKPOINT_DIR}"
+)
+
+# Run the conversion
+python3 -m ${CONVERT_MODULE} ${CONVERT_ARGS[@]}
+
+echo "Qwen3 MoE checkpoint saved to ${LOCAL_HF_CHECKPOINT_DIR}"

--- a/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
+++ b/MaxText/utils/ckpt_conversion/utils/hf_model_configs.py
@@ -61,4 +61,6 @@ HF_MODEL_CONFIGS = {
     "GEMMA2_2B": gemma2_2b_config,
     "GEMMA2_9B": gemma2_9b_config,
     "GEMMA2_27B": gemma2_27b_config,
+    # Default configuration for Qwen3 MoE models
+    "QWEN3_MOE": transformers.Qwen3MoeConfig(),
 }

--- a/end_to_end/tpu/qwen3_moe/1_test_qwen3_moe.sh
+++ b/end_to_end/tpu/qwen3_moe/1_test_qwen3_moe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Example script to convert a Qwen3 MoE checkpoint to MaxText format.
+set -ex
+idx=$(date +%Y-%m-%d)
+
+if [ -z "${BASE_OUTPUT_PATH}" ]; then
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)/
+    echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
+fi
+
+if [ -z "${MODEL_VARIATION}" ]; then
+    export MODEL_VARIATION="qwen3-moe"
+    echo "MODEL_VARIATION is not set, using MODEL_VARIATION = ${MODEL_VARIATION}"
+fi
+
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+export CHKPT_BUCKET=gs://maxtext-qwen3/${MODEL_VARIATION}/hf-checkpoint/
+export MODEL_BUCKET=gs://maxtext-qwen3/${MODEL_VARIATION}
+
+gcloud storage cp -r ${CHKPT_BUCKET} /tmp
+export LOCATION_OF_HF_CHKPT_ON_DISK=/tmp/hf-checkpoint
+
+JAX_PLATFORMS=cpu python3 -m MaxText.convert_qwen3_moe_ckpt --base_model_path ${LOCATION_OF_HF_CHKPT_ON_DISK} --maxtext_model_path ${MODEL_BUCKET}/${idx}/unscanned
+

--- a/end_to_end/tpu/qwen3_moe/2_test_qwen3_moe.sh
+++ b/end_to_end/tpu/qwen3_moe/2_test_qwen3_moe.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Run inference on a converted Qwen3 MoE checkpoint.
+set -ex
+idx=$(date +%Y-%m-%d)
+
+python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+if [ -z "${BASE_OUTPUT_PATH}" ]; then
+    export BASE_OUTPUT_PATH=gs://runner-maxtext-logs/$(date +%Y-%m-%d)/
+fi
+
+if [ -z "${MODEL_VARIATION}" ]; then
+    export MODEL_VARIATION="qwen3-moe"
+fi
+
+export TOKENIZER_PATH=gs://maxtext-qwen3/${MODEL_VARIATION}/hf-checkpoint/
+export MODEL_BUCKET=gs://maxtext-qwen3/${MODEL_VARIATION}
+export UNSCANNED_CKPT_PATH=${MODEL_BUCKET}/${idx}/unscanned/0/items
+
+python3 -m MaxText.tests.forward_pass_logit_checker MaxText/configs/base.yml tokenizer_path=${TOKENIZER_PATH} load_parameters_path=${UNSCANNED_CKPT_PATH} run_name=forward_pass_test_${MODEL_VARIATION} attention=dot_product per_device_batch_size=1 model_name=${MODEL_VARIATION} max_prefill_predict_length=4 max_target_length=4 scan_layers=false --atol=0.5 --rtol=0.5 async_checkpointing=false sparse_matmul=false weight_dtype=float32 dtype=float32
+

--- a/end_to_end/tpu/qwen3_moe/Run_Qwen3MoE.md
+++ b/end_to_end/tpu/qwen3_moe/Run_Qwen3MoE.md
@@ -1,0 +1,34 @@
+<!--
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Qwen3 MoE
+
+Qwen3 MoE is Alibaba's mixture-of-experts model family. This example shows how to
+convert the HuggingFace checkpoints for use with MaxText and run a small
+inference job on TPU.
+
+The workflow consists of two steps:
+1. Use `convert_qwen3_moe_ckpt.py` to convert the HuggingFace weights to MaxText
+   Orbax format using a CPU VM.
+2. Run `forward_pass_logit_checker.py` on a TPU VM with the converted weights.
+
+Scripts `1_test_qwen3_moe.sh` and `2_test_qwen3_moe.sh` in this directory
+provide sample commands for these two steps.
+
+To export a fine-tuned checkpoint back to HuggingFace format see
+`convert_qwen3_moe_to_hf.sh` in `utils/ckpt_conversion/examples` which wraps
+`MaxText.ckpt_conversion.to_huggingface` for the Qwen3 MoE model.
+


### PR DESCRIPTION
## Summary
- add script to convert Qwen3 MoE checkpoints back to HuggingFace
- document HuggingFace export workflow in Qwen3 MoE instructions

## Testing
- `bash unit_test_and_lint.sh` *(fails: No module named pylint, absl, jax, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684941abcdd8832d957ea57475cd425b